### PR TITLE
Pinning alpine version to 3.12 to fix the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 as builder
+FROM alpine:3.12 as builder
 ARG VERSION=3.3rc7
 WORKDIR /root
 RUN apk add --no-cache \
@@ -27,7 +27,7 @@ RUN autoreconf -i -f \
         && make \
         && make install
 
-FROM alpine:3
+FROM alpine:3.12
 RUN apk add --no-cache \
         dbus \
         alsa-lib \


### PR DESCRIPTION
scheduled build started failing with alpine 3.13 with errors such as:
```
/usr/lib/gcc/armv7-alpine-linux-musleabihf/10.2.1/../../../../armv7-alpine-linux-musleabihf/bin/ld: rtsp.o:/root/shairport-sync/rtsp.h:7: multiple definition of `conns'; shairport.o:/root/shairport-sync/rtsp.h:7: first defined here
...
```